### PR TITLE
Specify pre-release 3.0.0 version of Freya in NuGet

### DIFF
--- a/tutorials/getting-started.rst
+++ b/tutorials/getting-started.rst
@@ -63,7 +63,7 @@ Using your preferred method of managing Nuget dependencies, install the required
 
 .. code-block:: shell
 
-   PM> Install-Package Freya -Version 3.0.0-rc01
+   PM> Install-Package Freya -Pre
    PM> Install-Package Microsoft.Owin.SelfHost
 
 The Freya package is a meta-package -- it brings in all of the packages you'll need for a common Freya application.

--- a/tutorials/getting-started.rst
+++ b/tutorials/getting-started.rst
@@ -63,7 +63,7 @@ Using your preferred method of managing Nuget dependencies, install the required
 
 .. code-block:: shell
 
-   PM> Install-Package Freya
+   PM> Install-Package Freya -Version 3.0.0-rc01
    PM> Install-Package Microsoft.Owin.SelfHost
 
 The Freya package is a meta-package -- it brings in all of the packages you'll need for a common Freya application.


### PR DESCRIPTION
The code shown here doesn't currently compile if the Install-Package commands are run as shown, as Freya 2.0.23 (the latest released version) will be installed instead of 3.0.0.