### PR TITLE
Fixed Owin startup class method name: Configure -> Configuration

### DIFF
--- a/tutorials/getting-started.rst
+++ b/tutorials/getting-started.rst
@@ -81,7 +81,7 @@ At this point you should have an empty F# program. Start off by opening some com
 
 Greeting
 ^^^^^^^^
-   
+
 Now you're ready to implement the Freya part of your Hello World application. Start by creating these two functions:
 
 .. code-block:: fsharp
@@ -132,7 +132,7 @@ Now that you have all the "logic" covered you'll need a way of serving it. You c
 .. code-block:: fsharp
 
    type HelloWorld () =
-       member __.Configure () =
+       member __.Configuration () =
            OwinAppFunc.ofFreya (router)
 
    open System


### PR DESCRIPTION
The Configuration method name in the Owin startup class in the step-by-step part of the getting started tutorial was incorrect (it was called Configure). It is already correct in the introduction.