### PR TITLE
Update getting-started.rst

### DIFF
--- a/tutorials/getting-started.rst
+++ b/tutorials/getting-started.rst
@@ -132,7 +132,7 @@ Now that you have all the "logic" covered you'll need a way of serving it. You c
 .. code-block:: fsharp
 
    type HelloWorld () =
-       member __.Configure () =
+       member __.Configuration () =
            OwinAppFunc.ofFreya (router)
 
    open System


### PR DESCRIPTION
Changed `Configure()` member to `Configuration()`. I needed to do this - seems like latest version of Microsoft Owin Hosting looks for this by default (at least, it did for me when I went through the hello world sample).