### PR TITLE
Mention template

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -153,6 +153,12 @@
                     background-color: $c-p1;               
                 }
             }
+
+            .highlight {
+                pre {
+                    margin: 2em 0em 0em;
+                }
+            }
         }
     }
 }

--- a/index.html
+++ b/index.html
@@ -58,7 +58,13 @@ title: Home
   </section>
 
   <section class="prompt">
-    <p>Ready to give Freya a try? You could be <strong>up and running in minutes.</strong></p>
+    <p>Ready to give Freya a try? You could be <strong>up and running in minutes.</strong> Just install the Freya template through the dotnet CLI.</p>
+    <div class="highlight">
+      <pre>
+        <span class="k">dotnet new</span> <span class="n">--install</span> <span class="nv">Freya.Template::*</span>
+        <span class="k">dotnet new</span> <span class="nv">freya</span>
+      </pre>
+    </div>
     <p><a href="{{ site.docs.url }}/tutorials/getting-started.html">Get Started Now</a></p>
   </section>
 


### PR DESCRIPTION
Updates the homepage to mention the template as a quick-start.

After changes:
![image](https://cloud.githubusercontent.com/assets/18165/24916503/54900ec6-1ea8-11e7-8a22-4eba9de39bd2.png)

I've been able to build the site with Sphinx, but still not sure what it takes to deploy or any of that jazz.